### PR TITLE
site: add credits section

### DIFF
--- a/site/layouts/_default/home.html
+++ b/site/layouts/_default/home.html
@@ -22,6 +22,7 @@
               </nav>
               <a class="nav-link" href="#download">Download</a>
               <a class="nav-link" href="#schema-extensions">Schema Extensions</a>
+              <a class="nav-link" href="#credits">Credits</a>
               <a class="nav-link" href="#feedback">Feedback</a>
             </nav>
           </nav>
@@ -147,6 +148,8 @@
         <ul>
           <li><a href="{{ .Site.BaseURL }}/fsc">Forest Stewardship Council</a></li>
         </ul>
+        <h2 id="credits">Credits</h2>
+        <p>The ISEAL Core Metadata Set and FSC extension were compiled by Peter Ballantyne drawing on reviews of information systems and conversations with individuals in several organizations, notably FSC and ISEAL. The metadata were reviewed, improved and published on GitHub by Alan Orth and Marie-Angelique Laporte. Elizabeth Kennedy oversaw the data implementations and Julie Smith provided overall project management.</p>
         <h2 id="feedback">Feedback</h2>
         <p>If you have questions/comments please contact ____.</p>
       </main>


### PR DESCRIPTION
Add a simple credits section to the homepage. Looks like this:

![Screenshot 2022-03-01 at 21-23-54 ISEAL Core Metadata Set-fs8](https://user-images.githubusercontent.com/191754/156227156-aa413708-e8af-48d4-8f06-8c9fcbfaf453.png)

Closes #15